### PR TITLE
trigger pagination update event on successful drag

### DIFF
--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -55,6 +55,8 @@
 			if( newSlide ){
 				activeSlides[ 0 ].removeClass( activeClass ).css( "left", data.deltaX > 0 ? data.w  + "px" : -data.w  + "px" );
 				activeSlides[ 1 ].addClass( activeClass ).css( "left", 0 );
+
+                $( this ).trigger( "goto." + pluginName, activeSlides[ 1 ]);
 			}
 			else {
 				activeSlides[ 0 ].css( "left", 0);


### PR DESCRIPTION
Presently the pagination events only fire if you use the pagination controls. This adds triggering of the pagination event when the carousel is navigated via touch/drag.
