### PR TITLE
Prev/Next text can now be given in HTML using data attributes

### DIFF
--- a/src/responsive-carousel.js
+++ b/src/responsive-carousel.js
@@ -11,6 +11,10 @@
 	var pluginName = "carousel",
 		initSelector = "." + pluginName,
 		transitionAttr = "data-transition",
+		prevAttr = "data-prev",
+		prevTitleAttr = "data-prev-title",
+		nextAttr = "data-next",
+		nextTitleAttr = "data-next-title",
 		transitioningClass = pluginName + "-transitioning",
 		itemClass = pluginName + "-item",
 		activeClass = pluginName + "-active",
@@ -136,8 +140,13 @@
 			},
 			
 			_addNextPrev: function(){
+				var prev = $( this ).attr( prevAttr ) || "Prev",
+					next = $( this ).attr( nextAttr ) || "Next",
+					prevTitle = $( this ).attr( prevTitleAttr) || "Previous",
+					nextTitle = $( this ).attr( nextTitleAttr) || "Next",
+					navTag = "<nav class='" + navClass + "'><a href='#prev' class='prev' aria-hidden='true' title='" + prevTitle + "'>" + prev + "</a><a href='#next' class='next' aria-hidden='true' title='" + nextTitle + "'>" + next + "</a></nav>";
 				return $( this )
-					.append( "<nav class='"+ navClass +"'><a href='#prev' class='prev' aria-hidden='true' title='Previous'>Prev</a><a href='#next' class='next' aria-hidden='true' title='Next'>Next</a></nav>" )
+					.append( navTag )
 					[ pluginName ]( "_bindEventListeners" );
 			},
 			


### PR DESCRIPTION
I needed to change the Next/Prev link text and title for internationalization purposes, and thought the best place to do that is in the HTML, so I added a few data attributes that enable that.
In case the data attributes are missing, the text & title values remain the same as they are today.
