### PR TITLE
Vertical scrolling disabled on touch devices when horizontally scrolling a carousel

### DIFF
--- a/src/responsive-carousel.touch.js
+++ b/src/responsive-carousel.touch.js
@@ -48,6 +48,11 @@
 						setData( e );
 						if( data.touches.length === 1 ){
 							$( e.target ).closest( initSelector ).trigger( "drag" + e.type.split( "touch" )[ 1], data );
+							if(data.deltaX > 1 || data.deltaX < -1){
+								e.preventDefault();
+							} else {
+								return true;
+							}
 						}
 					};
 


### PR DESCRIPTION
This is a common behavior for carousels on touch devices. Accidental, high velocity vertical scrolls are common when the vertical scroll does not disable. It is now disabled when it senses the carousel scrolling horizontally.
