### PR TITLE
fixing-plugins: If the [data-autoplay] attribute is missing, do not run ...

### DIFF
--- a/src/responsive-carousel.autoplay.js
+++ b/src/responsive-carousel.autoplay.js
@@ -35,7 +35,7 @@
 			},
 			
 			_initAutoPlay: function(){
-				var autoplay = $( this ).attr( "data-autoplay");
+				var autoplay = $( this ).attr( "data-autoplay") || null;
 				if( autoplay === true || ( autoplay !== null && autoplay !== false ) ){
 					$( this )
 						[ pluginName ]( "_bindStopListener" )


### PR DESCRIPTION
If the `data-autoplay` attribute is not included `( autoplay !== null && autoplay !== false )` will evaluate to `true` and the autoplay plugin will run if included on the page.
If the attribute is missing, `$.attr('data-autoplay')` will return `undefined`.
I set autoplay to return null so in the case that the attribute is not there, then the conditional statement will evaluate to false and the plugin will not run.
