### PR TITLE
Plugin for click tracking

### DIFF
--- a/src/responsive-carousel.autoplay.js
+++ b/src/responsive-carousel.autoplay.js
@@ -35,7 +35,7 @@
 			},
 			
 			_initAutoPlay: function(){
-				var autoplay = $( this ).attr( "data-autoplay");
+				var autoplay = $( this ).attr( "data-autoplay") || null;
 				if( autoplay === true || ( autoplay !== null && autoplay !== false ) ){
 					$( this )
 						[ pluginName ]( "_bindStopListener" )

--- a/src/responsive-carousel.autoplay.js
+++ b/src/responsive-carousel.autoplay.js
@@ -35,8 +35,11 @@
 			},
 			
 			_initAutoPlay: function(){
-				var autoplay = $( this ).attr( "data-autoplay") || null;
-				if( autoplay === true || ( autoplay !== null && autoplay !== false ) ){
+				var autoplayAttr = $( this ).attr( "data-autoplay" ),
+					autoplay = ( autoplayAttr !== undefined ) ?
+						( autoplayAttr.toLowerCase() !== "false" ) :
+						false;
+				if( autoplay === true ){
 					$( this )
 						[ pluginName ]( "_bindStopListener" )
 						[ pluginName ]( "play" );

--- a/src/responsive-carousel.clicktracking.js
+++ b/src/responsive-carousel.clicktracking.js
@@ -17,19 +17,17 @@
 		trackParametersPrev = [ '_trackEvent' ],
 		methods = {
 			trackEvent: function( trackParameters ) {
-				if( _gaq !== undefined && _gaq.length ) {
+				if( window._gaq !== undefined ) {
 					_gaq.push( trackParameters );
 				}
 			},
 
-			m_next: function(){
+			c_next: function(){
 				$( this )[ pluginName ]( "trackEvent", trackParametersNext );
-				$( this )[ pluginName ]( "m_goTo", "+1" );
 			},
 
-			m_prev: function(){
+			c_prev: function(){
 				$( this )[ pluginName ]( "trackEvent", trackParametersPrev );
-				$( this )[ pluginName ]( "m_goTo", "-1" );
 			},
 
 			_bindClickTrackingEventListeners: function(){
@@ -37,7 +35,7 @@
 					.bind( "click", function( e ){
 						var targ = $( e.target ).closest( "a[href='#next'],a[href='#prev']" );
 						if( targ.length ){
-							$elem[ pluginName ]( targ.is( "[href='#next']" ) ? "m_next" : "m_prev" );
+							$elem[ pluginName ]( targ.is( "[href='#next']" ) ? "c_next" : "c_prev" );
 							e.preventDefault();
 						}
 					});

--- a/src/responsive-carousel.clicktracking.js
+++ b/src/responsive-carousel.clicktracking.js
@@ -70,7 +70,7 @@
 	$.extend( $.fn[ pluginName ].prototype, methods ); 
 	
 	// DOM-ready auto-init
-	$( initSelector ).on( "create." + pluginName, function(){
+	$( document ).on( "create." + pluginName, initSelector, function(){
 		$( this )[ pluginName ]( "_clickTrackingInit" );
 	} );
 }(jQuery));

--- a/src/responsive-carousel.clicktracking.js
+++ b/src/responsive-carousel.clicktracking.js
@@ -1,0 +1,78 @@
+/*
+ * responsive-carousel click tracking extension
+ * https://github.com/filamentgroup/responsive-carousel
+ *
+ * Copyright (c) 2014 Nara Logics, Inc.
+ * Licensed under the MIT, GPL licenses.
+ */
+
+(function( $, undefined ) {
+	var pluginName = "carousel",
+		initSelector = "." + pluginName,
+		dataAttributeName = "data-click-tracking",
+		dataAttributeNameNext = "data-click-tracking-next",
+		dataAttributeNamePrev = "data-click-tracking-prev",
+		attributeValueDelimiter = ",",
+		trackParametersNext = [ '_trackEvent' ],
+		trackParametersPrev = [ '_trackEvent' ],
+		methods = {
+			trackEvent: function( trackParameters ) {
+				if( _gaq !== undefined && _gaq.length ) {
+					_gaq.push( trackParameters );
+				}
+			},
+
+			m_next: function(){
+				$( this )[ pluginName ]( "trackEvent", trackParametersNext );
+				$( this )[ pluginName ]( "m_goTo", "+1" );
+			},
+
+			m_prev: function(){
+				$( this )[ pluginName ]( "trackEvent", trackParametersPrev );
+				$( this )[ pluginName ]( "m_goTo", "-1" );
+			},
+
+			_bindClickTrackingEventListeners: function(){
+				var $elem = $( this )
+					.bind( "click", function( e ){
+						var targ = $( e.target ).closest( "a[href='#next'],a[href='#prev']" );
+						if( targ.length ){
+							$elem[ pluginName ]( targ.is( "[href='#next']" ) ? "m_next" : "m_prev" );
+							e.preventDefault();
+						}
+					});
+				return this;
+			},
+
+			_trackingParametersInit: function(){
+				var nextAttr = $( this ).attr( dataAttributeNameNext ),
+					prevAttr = $( this ).attr( dataAttributeNamePrev );
+				trackParametersNext = ( nextAttr !== undefined ) ?
+						( trackParametersNext.concat( nextAttr.split( attributeValueDelimiter ) ) ) :
+						[];
+				trackParametersPrev = ( prevAttr !== undefined ) ?
+						( trackParametersPrev.concat( prevAttr.split( attributeValueDelimiter ) ) ) :
+						[];
+			},
+
+			_clickTrackingInit: function(){
+				var clickTrackingAttr = $( this ).attr( dataAttributeName ),
+					clickTracking = ( clickTrackingAttr !== undefined ) ?
+						( clickTrackingAttr.toLowerCase() !== "false" ) :
+						false;
+				if( clickTracking === true ){
+					$( this )
+						[ pluginName ]( "_bindClickTrackingEventListeners" )
+						[ pluginName ]( "_trackingParametersInit" );
+				}
+			}
+		};
+			
+	// add methods
+	$.extend( $.fn[ pluginName ].prototype, methods ); 
+	
+	// DOM-ready auto-init
+	$( initSelector ).on( "create." + pluginName, function(){
+		$( this )[ pluginName ]( "_clickTrackingInit" );
+	} );
+}(jQuery));

--- a/test/functional/clicktracking.html
+++ b/test/functional/clicktracking.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Responsive Carousel Demo Page</title>
+  <!-- Load local jQuery, removing access to $ (use jQuery, not $). -->
+  <script src="../../libs/jquery/jquery.js"></script>
+  <link rel="stylesheet" href="../../src/responsive-carousel.css" media="screen">
+  <link rel="stylesheet" href="../assets/demostyles.css">
+  <!-- Load local lib and tests. -->
+  <script src="../../src/responsive-carousel.js"></script>
+  <script src="../../src/responsive-carousel.autoinit.js"></script>
+  <script src="../../src/responsive-carousel.clicktracking.js"></script>
+  <script type="text/javascript">
+    window._gaq = []; /* mocked Google Analytics tracking array, on a real
+                       * system this will be an object
+                      */
+    // override the array push to output log entries to our list
+    window._gaq.push = function( array ) {
+      $( '#log' ).append( '<li>' + array.join( ', ' ) + '</li>' );
+    }
+  </script>
+</head>
+<body>
+	<div class="carousel" data-click-tracking data-click-tracking-next="User action,image_arrow,next" data-click-tracking-prev="User action,image_arrow,prev">
+	    <div>
+	        <img src="../assets/large.jpg">
+	    </div>
+	    <div>
+	        <img src="../assets/monks.jpg">
+	    </div>
+	    <div>
+	        <img src="../assets/monkey.jpg">
+	    </div>
+	</div>
+    <p>Press Prev/Next to see events added to the click tracker below</p>
+    <h3>Events are added to the Google Analytics _gaq:</h3>
+    <ul id=log></ul>
+</body>
+</html>

--- a/test/functional/index.html
+++ b/test/functional/index.html
@@ -11,6 +11,7 @@
 	<ul>
 		<li><a href="default.html">Default, no transitions</a>
 		<li><a href="no-loop.html">Default, no revolving content</a>
+		<li><a href="clicktracking.html">Default, with click tracking to for Prev / Next buttons</a>
 		<li><a href="fade.html">Fade transitions</a></li>
 		<li><a href="fade-auto.html">Fade with autoplay</a></li>
 		<li><a href="slide.html">Slide transition with touch</a></li>


### PR DESCRIPTION
The plugin and code for a click tracking feature. Allows the specifying of a few `data-` attributes that will push GA tracking events into the `_gaq`.

Example attributes:
`data-click-tracking data-click-tracking-next="User action,image_arrow,next" data-click-tracking-prev="User action,image_arrow,prev"`
