### PR TITLE
Using variable height content and multiple images per slide

### DIFF
--- a/src/responsive-carousel.dynamic-containers.js
+++ b/src/responsive-carousel.dynamic-containers.js
@@ -27,7 +27,7 @@
 					$kids = $( this ).find( "." + itemClass );
 				}
 				else{
-					$kids.appendTo( $self );
+					$kids.prependTo( $self );
 					$rows.remove();
 				}
 				


### PR DESCRIPTION
Changed to keep the navigation after the slides which allows the use of nth:child to style content of varying heights into a grid which then become slides by row.
/\* three wide carousel */
.newcarousel .slide {
  float: left;
  width: 33.3%;
}
.newcarousel .slide:nth-child(3n+1) {
  clear:left;
}
.newcarousel .newcarousel-item.slide:nth-child(1n) {
  clear:none;
}
