### PR TITLE
Remove 'div' from .carousel-item selector

### DIFF
--- a/src/responsive-carousel.pagination.js
+++ b/src/responsive-carousel.pagination.js
@@ -64,7 +64,7 @@
 					} )
 					// update pagination on page change
 					.bind( "goto." + pluginName, function( e, to  ){
-						var index = to ? $( this ).find( "div.carousel-item" ).index( to ) : 0;
+						var index = to ? $( this ).find( ".carousel-item" ).index( to ) : 0;
 
 						$( this ).find( "ol." + paginationClass + " li" )
 							.removeClass( activeClass )


### PR DESCRIPTION
There's no real reason to only use a `div`: `section`/`article`/`img` etc. all play nicely with the main JS, just pagination fails with the more specific selector in place.
