### PR TITLE
Successful touch drag fails to update pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
 	},
 	"license": "MIT",
 	"main": "dist/responsive-carousel.js",
-	"engines": {
-		"node": "~0.6"
-	},
 	"scripts": {
 		"test": "grunt travis --verbose"
 	},

--- a/src/responsive-carousel.js
+++ b/src/responsive-carousel.js
@@ -122,6 +122,10 @@
 					direction: nextNum > activeNum ? "forward" : "backward"
 				});
 
+				// NOTE this is a quick fix for the issue #15.
+				if( activeNum === nextNum ) {
+					return;
+				}
 
 				// NOTE this is a quick hack to approximate the api that jQuery provides
 				//      without depending on the API (for use with similarly shaped apis)

--- a/src/responsive-carousel.pagination.js
+++ b/src/responsive-carousel.pagination.js
@@ -64,7 +64,7 @@
 					} )
 					// update pagination on page change
 					.bind( "goto." + pluginName, function( e, to  ){
-						var index = to ? $( this ).find( "div.carousel-item" ).index( to.get( 0 ) ) : 0;
+						var index = to ? $( this ).find( "div.carousel-item" ).index( $( to ).get( 0 ) ) : 0;
 
 						$( this ).find( "ol." + paginationClass + " li" )
 							.removeClass( activeClass )


### PR DESCRIPTION
I've required the following javascript files to my module:
- `responsive-carousel.js`
- `responsive-carousel.touch.js`
- `responsive-carousel.drag.js`
- `responsive-carousel.pagination.js`
- `responsive-carousel.autoinit.js`

On `$(document).ready()` I `$(document).trigger("enhance");` and all my carousels are initialized.

Now, clicking the pagination numbers all works fine. It's the same for next and prev links. The touch and touch drag also work fine. No errors. Except one.

```
Uncaught TypeError: to.get is not a function
```

The error is caused by line `67` in the `responsive-carousel.pagination.js` file. It looks like this:

```
var index = to ? $( this ).find( "div.carousel-item" ).index( to.get( 0 ) ) : 0;
```

When the event for updating the pagination is triggered on the mentioned line it tries to access a jQuery method `.get()` on the `to` object. The problem is that in my particular case the for some reason the `to` is not a jQuery object so it can't access the `.get()` method and it fails to update the pagination.

Just by wrapping the `to` to `$()` like this `$(to)` the error goes away. Though I'm not sure if this is correct way to fix this.
