### PR TITLE
This feature test needed a standard non-prefixed version. 

### DIFF
--- a/src/responsive-carousel.js
+++ b/src/responsive-carousel.js
@@ -30,8 +30,11 @@
 				supported = false,
 				property;
 
+			prefixes.push("");
+
 			while( prefixes.length ){
-				property = prefixes.shift() + "Transition";
+				property = prefixes.shift();
+				property += (property === "" ? "t" : "T" )+ "ransition";
 
 				if ( property in document.documentElement.style !== undefined && property in document.documentElement.style !== false ) {
 					supported = true;


### PR DESCRIPTION
Apparently, IE11 doesn't support prior prefixed versions that otherwise pass in most any browser.