### PR TITLE
150

### DIFF
--- a/src/responsive-carousel.js
+++ b/src/responsive-carousel.js
@@ -196,6 +196,21 @@
 
 			_transitionEnd: function( $from, $to, reverseClass, index ){
 				$( this ).removeClass( reverseClass );
+
+				// If the slides are moving forward prevent, the previous slide from
+				// transitioning slowly to the slide stack.
+
+				// This prevents botched transitions for 2 slide carousels because,
+				// unless there's a third slide to move into position from the right,
+				// the slow transition to the stack can leave it in an intermediate
+				// state when the user clicks "next" again.
+				if( !reverseClass ){
+					$from.addClass("no-transition");
+					setTimeout(function(){
+						$from.removeClass("no-transition");
+					});
+				}
+
 				$from.removeClass( outClass + " " + activeClass );
 				$to.removeClass( inClass ).addClass( activeClass );
 				$( this )[ pluginName ]( "update" );

--- a/src/responsive-carousel.slide.css
+++ b/src/responsive-carousel.slide.css
@@ -62,3 +62,6 @@
 .carousel-slide-reverse .carousel-active {
 	left: 0;
 }
+.carousel-item.no-transition {
+  transition: none !important;
+}

--- a/test/functional/index.html
+++ b/test/functional/index.html
@@ -15,6 +15,7 @@
 		<li><a href="fade.html">Fade transitions</a></li>
 		<li><a href="fade-auto.html">Fade with autoplay</a></li>
 		<li><a href="slide.html">Slide transition with touch</a></li>
+		<li><a href="slide-two.html">Slide transition with touch, only two slides</a></li>
 		<li><a href="slide-keybd.html">Slide transition with touch and arrow keys</a></li>
 		<li><a href="slide-auto.html">Autoplay slide transition with touch and arrow keys</a></li>
 		<li><a href="ajax.html">Ajax-included extra slides (w/ slide transition)</a></li>

--- a/test/functional/slide-two.html
+++ b/test/functional/slide-two.html
@@ -15,7 +15,7 @@
   <script src="../../src/responsive-carousel.drag.js"></script>
   <script src="../../src/responsive-carousel.autoinit.js"></script>
   <script src="../../src/globalenhance.js"></script>
-  <stylesheet>
+  <style>
     .carousel-slide .carousel-item {
       -webkit-transition: left 2s ease;
       -moz-transition: left 2s ease;
@@ -23,7 +23,7 @@
       -o-transition: left 2s ease;
       transition: left 2s ease;
     }
-  </stylesheet>
+  </style>
 </head>
 <body>
 	<div class="carousel" data-transition="slide">

--- a/test/functional/slide-two.html
+++ b/test/functional/slide-two.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Responsive Carousel Demo Page</title>
+  <!-- Load local jQuery, removing access to $ (use jQuery, not $). -->
+  <script src="../../libs/jquery/jquery.js"></script>
+  <link rel="stylesheet" href="../../src/responsive-carousel.css" media="screen">
+  <link rel="stylesheet" href="../../src/responsive-carousel.slide.css" media="screen">
+  <link rel="stylesheet" href="../assets/demostyles.css">
+  <!-- Load local lib and tests. -->
+  <script src="../../src/responsive-carousel.js"></script>
+  <script src="../../src/responsive-carousel.touch.js"></script>
+  <script src="../../src/responsive-carousel.drag.js"></script>
+  <script src="../../src/responsive-carousel.autoinit.js"></script>
+  <script src="../../src/globalenhance.js"></script>
+  <stylesheet>
+    .carousel-slide .carousel-item {
+      -webkit-transition: left 2s ease;
+      -moz-transition: left 2s ease;
+      -ms-transition: left 2s ease;
+      -o-transition: left 2s ease;
+      transition: left 2s ease;
+    }
+  </stylesheet>
+</head>
+<body>
+	<div class="carousel" data-transition="slide">
+	    <div>
+	        <img src="../assets/large.jpg">
+	    </div>
+	    <div>
+	        <img src="../assets/monks.jpg">
+	    </div>
+	</div>
+
+</body>
+</html>

--- a/test/functional/slide.html
+++ b/test/functional/slide.html
@@ -24,10 +24,11 @@
 	    <div>
 	        <img src="../assets/monks.jpg">
 	    </div>
-      <div>
+	    <div>
 	        <img src="../assets/monkey.jpg">
-      </div>
-  </div>
+	    </div>
+		
+	</div>
 
 
 </body>

--- a/test/functional/slide.html
+++ b/test/functional/slide.html
@@ -24,7 +24,11 @@
 	    <div>
 	        <img src="../assets/monks.jpg">
 	    </div>
-	</div>
+      <div>
+	        <img src="../assets/monkey.jpg">
+      </div>
+  </div>
+
 
 </body>
 </html>

--- a/test/functional/slide.html
+++ b/test/functional/slide.html
@@ -24,12 +24,7 @@
 	    <div>
 	        <img src="../assets/monks.jpg">
 	    </div>
-	    <div>
-	        <img src="../assets/monkey.jpg">
-	    </div>
-		
 	</div>
-
 
 </body>
 </html>


### PR DESCRIPTION
Closes #150 

You see more about how to reproduce the issue in the discussion of #150. 

For comparison:

Broken:
https://150-bad-origin-responsive-carousel.fgview.com/test/functional/slide-two.html

Fixed:
https://150-origin-responsive-carousel.fgview.com/test/functional/slide-two.html

To reproduce in the broken version:

1. click the next link
2. wait for the transition to end (link is disabled until it ends)
3. click the next link quickly after the transition finishes 
4. it'll do something bizarre 

The problem is fixed in the branch for this PR

@scottjehl it's not clear to me why this isn't a problem in the other direction. I do not attempt to address the other direction in this PR.