### PR TITLE
only disable transitions for touches outside nav

### DIFF
--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -38,30 +38,41 @@
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
 				var activeSlides = getActiveSlides( $( e.target ), data.deltaX );
 
+				activeSlides[ 0 ].addClass("no-transition");
+				activeSlides[ 1 ].addClass("no-transition");
+
 				activeSlides[ 0 ].css( "left", data.deltaX + "px" );
 				activeSlides[ 1 ].css( "left", data.deltaX < 0 ? data.w + data.deltaX + "px" : -data.w + data.deltaX + "px" );
 			}
-		} )
+		})
 		.bind( pluginName + ".dragend", function( e, data ){
 			if( !!data && !dragThreshold( data.deltaX ) ){
 				return;
 			}
+
 			var activeSlides = getActiveSlides( $( e.target ), data.deltaX ),
-				newSlide = Math.abs( data.deltaX ) > 45;
+					newSlide = Math.abs( data.deltaX ) > 45;
+
+			activeSlides[ 0 ].addClass("fast");
+			activeSlides[ 1 ].addClass("fast");
+			activeSlides[ 0 ].removeClass("no-transition");
+			activeSlides[ 1 ].removeClass("no-transition");
 
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
 				$( e.target ).one( navigator.userAgent.indexOf( "AppleWebKit" ) ? "webkitTransitionEnd" : "transitionEnd", function(){
 					activeSlides[ 0 ].add( activeSlides[ 1 ] ).css( "left", "" );
 					$( e.target ).trigger( "goto." + pluginName, activeSlides[ newSlide ? 1 : 0 ] );
+					activeSlides[ 0 ].removeClass("fast");
+					activeSlides[ 1 ].removeClass("fast");
 				});
 
 				if( newSlide ){
-					activeSlides[ 0 ].removeClass( activeClass ).css( "left", data.deltaX > 0 ? data.w  + "px" : -data.w  + "px" );
+					activeSlides[ 0 ].removeClass( activeClass ).css( "left", data.deltaX > 0 ? data.w	+ "px" : -data.w	+ "px" );
 					activeSlides[ 1 ].addClass( activeClass ).css( "left", 0 );
 				}
 				else {
 					activeSlides[ 0 ].css( "left", 0);
-					activeSlides[ 1 ].css( "left", data.deltaX > 0 ? -data.w  + "px" : data.w  + "px" );
+					activeSlides[ 1 ].css( "left", data.deltaX > 0 ? -data.w	+ "px" : data.w	 + "px" );
 				}
 			}
 			else if( newSlide ){

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -73,7 +73,7 @@
 			var $both = $current.add($next);
 
 			// add the fast transition class to make transitions out of a drag quick
-			// remove any no-transition class
+			// remove any no-transition class so the transition out of the drag can work
 			$both
 				.addClass("fast")
 				.removeClass("no-transition");

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -75,7 +75,7 @@
 
 			// add the fast transition class to make transitions out of a drag quick
 			// remove any no-transition class so the transition out of the drag can work
-			$carousel.addClass("carousel-fast-transition");
+			$carousel.addClass("carousel-autoplay-stopped");
 			$both.removeClass("no-transition");
 
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
@@ -93,7 +93,7 @@
 					$( e.target ).trigger( "goto." + pluginName, newSlide ? $next : $current );
 
 					// remove the fast transition class so that other transitions can be slow
-					$carousel.removeClass("carousel-fast-transition");
+					$carousel.removeClass("carousel-autoplay-stopped");
 
 					// do the post transition cleanup to make sure that the state in the
 					// component is sane for future transitions and navigation
@@ -107,12 +107,15 @@
 				// if we're heading to a new slide move the slide out
 				(newSlide ? $current : $next)
 					.removeClass( activeClass )
-					.css( "left", data.deltaX > 0 ? data.w	+ "px" : -data.w	+ "px" );
+					.css( "left",
+								newSlide ?
+								(data.deltaX > 0 ? data.w	+ "px" : -data.w	+ "px") :
+								(data.deltaX > 0 ? -data.w	+ "px" : data.w	+ "px"));
 
 				// if we're heading to a new slide move the next one in
 				(newSlide ? $next : $current)
 					.addClass( activeClass )
-					.css( "left", 0);
+					.css( "left", 0 );
 			} else if( newSlide ){
 				$( e.target )[ pluginName ]( data.deltaX > 0 ? "prev" : "next" );
 			}

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -75,7 +75,7 @@
 			// add the fast transition class to make transitions out of a drag quick
 			// remove any no-transition class so the transition out of the drag can work
 			$both
-				.addClass("fast")
+				.addClass("fast-transition")
 				.removeClass("no-transition");
 
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
@@ -93,7 +93,7 @@
 					$( e.target ).trigger( "goto." + pluginName, newSlide ? $next : $current );
 
 					// remove the fast transition class so that other transitions can be slow
-					$both.removeClass("fast");
+					$both.removeClass("fast-transition");
 
 					// do the post transition cleanup to make sure that the state in the
 					// component is sane for future transitions and navigation

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -61,22 +61,22 @@
 				return;
 			}
 
-			var activeSlides = getActiveSlides( $( e.target ), data.deltaX ),
-					newSlide = Math.abs( data.deltaX ) > 45;
+			var activeSlides = getActiveSlides( $( e.target ), data.deltaX );
+			var $current = activeSlides[ 0 ];
+			var $next = activeSlides[ 1 ];
+			var $both = $current.add($next);
+			var $carousel = $current.closest(".carousel");
+
 
 			// use the absolute position from the left of the "from" slide to determine where
 			// thing should end up
 			newSlide = Math.abs(parseFloat(activeSlides[0].css("left").replace("px", ""))) > 45;
 
-			var $current = activeSlides[ 0 ];
-			var $next = activeSlides[ 1 ];
-			var $both = $current.add($next);
 
 			// add the fast transition class to make transitions out of a drag quick
 			// remove any no-transition class so the transition out of the drag can work
-			$both
-				.addClass("fast-transition")
-				.removeClass("no-transition");
+			$carousel.addClass("carousel-fast-transition");
+			$both.removeClass("no-transition");
 
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
 				$( e.target ).one( endEvent, function(){
@@ -93,11 +93,10 @@
 					$( e.target ).trigger( "goto." + pluginName, newSlide ? $next : $current );
 
 					// remove the fast transition class so that other transitions can be slow
-					$both.removeClass("fast-transition");
+					$carousel.removeClass("carousel-fast-transition");
 
 					// do the post transition cleanup to make sure that the state in the
 					// component is sane for future transitions and navigation
-					var $carousel = $current.closest(".carousel");
 					if( newSlide ) {
 							$carousel.carousel("_postTransitionCleanup", $current, $next);
 					} else {

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -70,14 +70,13 @@
 
 			var $left = activeSlides[ 0 ];
 			var $right = activeSlides[ 1 ];
+			var $both = $left.add($right);
 
 			// add the fast transition class to make transitions out of a drag quick
-			$left.addClass("fast");
-			$right.addClass("fast");
-
 			// remove any no-transition class
-			$left.removeClass("no-transition");
-			$right.removeClass("no-transition");
+			$both
+				.addClass("fast")
+				.removeClass("no-transition");
 
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
 				$( e.target ).one( endEvent, function(){
@@ -94,8 +93,7 @@
 					$( e.target ).trigger( "goto." + pluginName, newSlide ? $right : $left );
 
 					// remove the fast transition class so that other transitions can be slow
-					$left.removeClass("fast");
-					$right.removeClass("fast");
+					$both.removeClass("fast");
 
 					// do the post transition cleanup to make sure that the state in the component
 					if( newSlide ) {

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -109,23 +109,13 @@
 					}
 				});
 
-				if( newSlide ){
-					$left
-						.removeClass( activeClass )
-						.css( "left", data.deltaX > 0 ? data.w	+ "px" : -data.w	+ "px" );
+				(newSlide ? $left : $right)
+					.removeClass( activeClass )
+					.css( "left", data.deltaX > 0 ? data.w	+ "px" : -data.w	+ "px" );
 
-					$right
-						.addClass( activeClass )
-						.css( "left", 0 );
-				} else {
-					$left
-						.addClass( activeClass )
-						.css( "left", 0);
-
-					$right
-						.removeClass( activeClass )
-						.css( "left", data.deltaX > 0 ? -data.w	+ "px" : data.w	 + "px" );
-				}
+				(newSlide ? $right : $left)
+					.addClass( activeClass )
+					.css( "left", 0);
 			} else if( newSlide ){
 				$( e.target )[ pluginName ]( data.deltaX > 0 ? "prev" : "next" );
 			}

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -81,8 +81,8 @@
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
 				$( e.target ).one( endEvent, function(){
 
-					// add no transition to the slide that's going out and
-					// needs to move back to the stack
+					// add no transition to the slide that's going out and needs to move
+					// back to the stack fast
 					var $out = (newSlide ? $current : $next);
 					$out.addClass("no-transition");
 					setTimeout(function(){

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -40,20 +40,20 @@
 
 			if( $( e.target ).attr( "data-transition" ) === "slide" ){
 				var activeSlides = getActiveSlides( $( e.target ), data.deltaX );
-				var $left = activeSlides[ 0 ];
-				var $right = activeSlides[ 1 ];
+				var $current = activeSlides[ 0 ];
+				var $next = activeSlides[ 1 ];
 
 				// remove any transition classes in case drag happened in the middle
 				// of another transition and prevent any other transitions while dragging
 				// also unbind transition end events from the main component to prevent
 				// class application and other behavior from applying after the drag ends
-				$left.add($right)
+				$current.add($next)
 					.removeClass("carousel-in carousel-out")
 					.addClass("no-transition")
 					.unbind(endEvent);
 
-				$left.css( "left", data.deltaX + "px" );
-				$right.css( "left", data.deltaX < 0 ? data.w + data.deltaX + "px" : -data.w + data.deltaX + "px" );
+				$current.css( "left", data.deltaX + "px" );
+				$next.css( "left", data.deltaX < 0 ? data.w + data.deltaX + "px" : -data.w + data.deltaX + "px" );
 			}
 		})
 		.bind( pluginName + ".dragend", function( e, data ){
@@ -68,9 +68,9 @@
 			// thing should end up
 			newSlide = Math.abs(parseFloat(activeSlides[0].css("left").replace("px", ""))) > 45;
 
-			var $left = activeSlides[ 0 ];
-			var $right = activeSlides[ 1 ];
-			var $both = $left.add($right);
+			var $current = activeSlides[ 0 ];
+			var $next = activeSlides[ 1 ];
+			var $both = $current.add($next);
 
 			// add the fast transition class to make transitions out of a drag quick
 			// remove any no-transition class
@@ -83,35 +83,35 @@
 
 					// add no transition to the slide that's going out and
 					// needs to move back to the stack
-					var $out = (newSlide ? $left : $right);
+					var $out = (newSlide ? $current : $next);
 					$out.addClass("no-transition");
 					setTimeout(function(){
 						$out.removeClass("no-transition");
 					}, 20);
 
-					$left.add( $right ).css( "left", "" );
-					$( e.target ).trigger( "goto." + pluginName, newSlide ? $right : $left );
+					$current.add( $next ).css( "left", "" );
+					$( e.target ).trigger( "goto." + pluginName, newSlide ? $next : $current );
 
 					// remove the fast transition class so that other transitions can be slow
 					$both.removeClass("fast");
 
 					// do the post transition cleanup to make sure that the state in the component
 					if( newSlide ) {
-						$left
+						$current
 							.closest(".carousel")
-							.carousel("_postTransitionCleanup", $left, $right);
+							.carousel("_postTransitionCleanup", $current, $next);
 					} else {
-						$left
+						$current
 							.closest(".carousel")
-							.carousel("_postTransitionCleanup", $left, $right);
+							.carousel("_postTransitionCleanup", $next, $current);
 					}
 				});
 
-				(newSlide ? $left : $right)
+				(newSlide ? $current : $next)
 					.removeClass( activeClass )
 					.css( "left", data.deltaX > 0 ? data.w	+ "px" : -data.w	+ "px" );
 
-				(newSlide ? $right : $left)
+				(newSlide ? $next : $current)
 					.addClass( activeClass )
 					.css( "left", 0);
 			} else if( newSlide ){

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -95,15 +95,13 @@
 					// remove the fast transition class so that other transitions can be slow
 					$both.removeClass("fast");
 
-					// do the post transition cleanup to make sure that the state in the component
+					// do the post transition cleanup to make sure that the state in the
+					// component is sane for future transitions and navigation
+					var $carousel = $current.closest(".carousel");
 					if( newSlide ) {
-						$current
-							.closest(".carousel")
-							.carousel("_postTransitionCleanup", $current, $next);
+							$carousel.carousel("_postTransitionCleanup", $current, $next);
 					} else {
-						$current
-							.closest(".carousel")
-							.carousel("_postTransitionCleanup", $next, $current);
+							$carousel.carousel("_postTransitionCleanup", $next, $current);
 					}
 				});
 

--- a/src/responsive-carousel.drag.js
+++ b/src/responsive-carousel.drag.js
@@ -107,10 +107,12 @@
 					}
 				});
 
+				// if we're heading to a new slide move the slide out
 				(newSlide ? $current : $next)
 					.removeClass( activeClass )
 					.css( "left", data.deltaX > 0 ? data.w	+ "px" : -data.w	+ "px" );
 
+				// if we're heading to a new slide move the next one in
 				(newSlide ? $next : $current)
 					.addClass( activeClass )
 					.css( "left", 0);

--- a/src/responsive-carousel.slide.css
+++ b/src/responsive-carousel.slide.css
@@ -65,7 +65,7 @@
 .carousel-item.no-transition {
 	transition: none !important;
 }
-.carousel-slide.carousel-fast-transition .carousel-item {
+.carousel-slide.carousel-autoplay-stopped .carousel-item {
 	-webkit-transition: left .1s ease;
 	-moz-transition: left .1s ease;
 	-ms-transition: left .1s ease;

--- a/src/responsive-carousel.slide.css
+++ b/src/responsive-carousel.slide.css
@@ -63,5 +63,13 @@
 	left: 0;
 }
 .carousel-item.no-transition {
-  transition: none !important;
+	transition: none !important;
+}
+.carousel-slide .carousel-item.fast-transition,
+.carousel-slide-reverse .carousel-item.fast-transition {
+	-webkit-transition: left .1s ease;
+	-moz-transition: left .1s ease;
+	-ms-transition: left .1s ease;
+	-o-transition: left .1s ease;
+	transition: left .1s ease;
 }

--- a/src/responsive-carousel.slide.css
+++ b/src/responsive-carousel.slide.css
@@ -65,8 +65,7 @@
 .carousel-item.no-transition {
 	transition: none !important;
 }
-.carousel-slide .carousel-item.fast-transition,
-.carousel-slide-reverse .carousel-item.fast-transition {
+.carousel-slide.carousel-fast-transition .carousel-item {
 	-webkit-transition: left .1s ease;
 	-moz-transition: left .1s ease;
 	-ms-transition: left .1s ease;

--- a/src/responsive-carousel.touch.js
+++ b/src/responsive-carousel.touch.js
@@ -54,7 +54,10 @@
 
 				$( this )
 					.bind( "touchstart", function( e ){
-						$( this ).addClass( noTrans );
+						// TODO move to component method
+						if( !$(e.target).is("a.next") && !$(e.target).is("a.prev") ){
+							$( this ).addClass( noTrans );
+						}
 						emitEvents( e );
 					} )
 					.bind( "touchmove", function( e ){

--- a/test/functional/slide-two.html
+++ b/test/functional/slide-two.html
@@ -33,12 +33,12 @@
    }
 
    .carousel-item.fast {
-      -webkit-transition: left .1s ease;
-      -moz-transition: left .1s ease;
-      -ms-transition: left .1s ease;
-      -o-transition: left .1s ease;
-      transition: left .1s ease;
-    }
+     -webkit-transition: left .1s ease;
+     -moz-transition: left .1s ease;
+     -ms-transition: left .1s ease;
+     -o-transition: left .1s ease;
+     transition: left .1s ease;
+   }
 
    .carousel-slide-reverse .carousel-item {
      -webkit-transition: left 2s ease;

--- a/test/functional/slide-two.html
+++ b/test/functional/slide-two.html
@@ -31,6 +31,22 @@
      -o-transition: left 2s ease;
      transition: left 2s ease;
    }
+
+   .carousel-item.fast {
+      -webkit-transition: left .1s ease;
+      -moz-transition: left .1s ease;
+      -ms-transition: left .1s ease;
+      -o-transition: left .1s ease;
+      transition: left .1s ease;
+    }
+
+   .carousel-slide-reverse .carousel-item {
+     -webkit-transition: left 2s ease;
+     -moz-transition: left 2s ease;
+     -ms-transition: left 2s ease;
+     -o-transition: left 2s ease;
+     transition: left 2s ease;
+   }
   </style>
 </head>
 <body>

--- a/test/functional/slide-two.html
+++ b/test/functional/slide-two.html
@@ -32,14 +32,6 @@
      transition: left 2s ease;
    }
 
-   .carousel-item.fast {
-     -webkit-transition: left .1s ease;
-     -moz-transition: left .1s ease;
-     -ms-transition: left .1s ease;
-     -o-transition: left .1s ease;
-     transition: left .1s ease;
-   }
-
    .carousel-slide-reverse .carousel-item {
      -webkit-transition: left 2s ease;
      -moz-transition: left 2s ease;


### PR DESCRIPTION
Preventing transitions on `touchstart` can disable transitions in the main component which will prevent the plugin from re-enabling navigation. Avoid trigging the drag events when the touchstart comes from the nav elements.